### PR TITLE
Refactoring docs to present all the platform

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,33 +1,102 @@
-Welcome to Resonance AI documentation!
-======================================================
+.. _intro:
 
-Welcome to the official reference for developing with Resonance AI powered by Atooma.
+Introduction
+=======================================
 
-.. note::
+This tutorial is intended to get you up and running with the Resonance AI environment. 
 
-	This documentation is a work in progress. We are working hard every day for providing all of you an awesome developer experience, so stay tuned!
+**Atooma**'s Resonance AI is a highly integrated and concurrent software engine designed to manage interconnected devices and data streams flowing among apps services and businesses. A **Resonance AI Application** is the realization of a tool that can interconnect all the devices embedding the **Resonance SDK**. Briefly, Resonance AI smooths the great complexity implied in managing a large network of devices, to supply the user with all the possibilities given by the Internet Of Things.
 
-	Documentation sources are available on `GitHub <https://github.com/atooma/doc-resonance-ai>`_, so if you find typos, errors, or think something can be communicated better, fork repository and make a pull request.
+Resonance AI has been designed focusing on:
 
-	We appreciate your understanding and patience!
+* `contexts awareness <https://en.wikipedia.org/wiki/Context_awareness>`_ for your devices: know your peers and gather better intelligence to design better products, 
+* modularity in building streams of data from different sources: simply manage developing activities and usage scenarios for your products,
+* integration of multiple sources for verticals needed by your business: add value to your products by leveraging multiple data sources,
+* live notifications and suggestions to thousands of devices: get feedback from and operate your devices instantly.
 
-This documentation is aimed to provide in depth details on how to approach development and it is organized as follows:
+These incredible super-powers are made possible by the tools implemented by Resonance. A Resonance AI Application is an instance of the harmonic stacking of:
 
-.. toctree::
-	:numbered:
-	:maxdepth: 1
+* the cloud-based Resonance Dashboard,
+* the cloud-based Resonance Rule Engine,
+* the Resonance SDK deployed in the devices running your app.
 
-	intro
-	getstart
-	iosstart
-	android
-	contextapi
-	infoapi
+Basics
+======================================
 
-..
-	* :ref:`intro` - Here you can find answers to questions like *what is Resonance?* and *what can I do with Resonance SDK?*. Your understanding of Atooma potential starts from here!
-	* :ref:`getstart` - The first step!
-	* :ref:`iosstart` - The iOS first step!
-	* :ref:`android` - The Android first step!
-	* :ref:`contextapi` - Context API section.
-	* :ref:`infoapi` - Info API section.
+Resonance SDK is the core that powers any kind of mobile or embedded app you may want to develop to enhance your business. It has been designed along with the great experience at Atooma, collected by serving thousands of users and enabling millions of IF-DO rules. The **Resonance Rule Engine** carries on billions of operations by communicating real-time with all the devices running the SDK. You can create your app perfectly fitting your business model and integrate our SDK into it, to get all the advantages of our platform. Once you embed the Resonance SDK in one of your app you get all the advantages of a Resonance-powered app.   
+
+A Resonance AI Application looks over all the devices embedding the SDK; your network of devices can be operated via the **Resonance Dashboard**: a Web-based control panel from which applications running on multiple devices can be monitored and operated; rules and notifications can be triggered and propagated to devices.
+
+We'll walk through from setting up to **running your own Resonance AI Application**.
+
+To set up a Resonance AI Application you need to have first access to the Resonance Dashboard: create a Project to obtain an API Key to embed the SDK in your devices. Once you created a Project, you can deploy your API Key within your Resonance-powered apps and start making data useful for your business. Contact us for a trial `here <link to trial page>`_.
+
+Create a Resonance-powered app for your business
+-----------------------------------------------------------
+
+Resonance-powered apps are Android/iOS/Web based applications or devices that allow a user to leverage on the power of connecting multiple devices and apps together, with the final goal to give at final users a contextual experience application: automating recurring tasks and suggesting actions.
+
+Furthermore sensors, apps and devices are all managed by Resonance as key enabler to new generations of smart devices designed to:
+
+* **Listen** to people’s behavior across apps and devices.
+
+* **Analyze** the patterns and get the most out of them.
+
+* **Act** accordingly with the desired action in the right moment for a magic experience.
+
+By embedding our SDK in your app you deploy the magic of IoT to devices. This magic can be deployed and delivered to customers using your Resonance AI Application.
+
+You can access documentation about how the SDK works and how it can be embedded into any Android/iOS/Web application `here <add internal link to /intro>`_.
+
+Once you have your app running on many devices, you can enjoy the simplicity of managing your network from the `Resonance Dashboard <link to dashboard doc>`_. Contact us for a trial `here <link to trial page>`_.
+
+Our Story as a Company
+=========================================
+
+What We Believe?
+-----------------------------------------------------
+
+Within 2020 the number of connected devices will be over than 50 Billion.
+From Connected Cars to Smart Homes, from Wearables to Smartphones all things are getting connected and more intelligent everyday.
+
+Devices are still far from each other - they do not talk - they do not provide cool and useful cross-use-cases to end users. How many of you are using a Smart TV, not only to watch TV programs? How many of you are considering useful a smartwatch device after the first week of adoption?
+
+As result, end users got lost among different OSs and Devices Capabilities turning their connected and smart experience into a nightmare.
+Resonance bring again the user at the centre of the picture, seamlessly connecting devices around him and providing real context aware and predictive aware features.
+
+Developers and Companies focused on building IOT devices and/or Apps can rely on a perfect tool to empower their products capabilities and turning them into a real context aware space.
+
+What Is Resonance - Why There Is An Atooma App On The Market?
+---------------------------------------------------------------------
+
+Atooma App was born initially as an Android (also on a light-version for iOS) application aimed to allow end users to create and share automation rules following the *IF and DO* paradigm.
+
+So, using Atooma App users are able to create rules like: *IF I'm running and I plug the headphone DO Launch the music* or *IF I'm driving back to home and my battery level is below 10% DO send an SMS to my wife*.
+
+Today more than 25M of rules have been created and shared among our community and hundreds of apps and devices features are controlled by the Resonance Rule Engine.
+
+Building our own App and product has been a perfect strategy to understand what people love to automate in their life. What they are looking to turn smart into their devices or apps and why they found even hard to use a toolkit like our consumer App.
+
+What Is Resonance SDK?
+-----------------------------------------------------
+
+Such a great validation convinced our team to extend such contextual capabilities not only to the end user’s hands but directly towards device vendors and app developers team.
+
+Imagine to be able to connect your temperature sensor to our engine and being able to enable contextual experiences on your Smart Home App like: *Every Time the temperature threshold is below a certain level and I'm out of home, activate the air conditioning and store the electrical consumptions info into a Drive Doc*. Well, using the Resonance SDK, you can do it in a matter of seconds!
+
+We estimated every developer can save up to *60%* of coding lines to build context aware use cases by relying on our tools.
+
+We do provide to third party developers a full standalone Platform to collect and to analyze data from a lot of devices and to create intelligence contextual automation with a set of embedded modules to start immediately to build automation use cases just by matching basic lines of LUA scripts using a web console.
+On top of it developers have the opportunity to create their own sensors modules and plug them with our Resonance Cloud platform and leverage on real time prediction based rule suggestions.
+
+We do provide external developers a set of APIs which leverage on the fact that Resonance is able to collect user's behaviors information among hundreds of sensors and apps with the final result to be able to to let your App be aware of what the user is going to do. Imagine to have an API able to let you know if the user is driving back home from work or just simply to understand if the user is in a Bus rather than a Car.
+Having such contextual information then you'll be able to proceed by coding a specific reaction on your own app or eventually leverage on the Resonance Rule Engine to be able to trigger an automation rule based on such context prediction.
+
+Full documentation available `here <add internal link to /intro>`_.
+
+.. _intro-needs:
+
+What You Need?
+-----------------------------------------------------
+
+Using our platform is super simple: Register for a Dashboard, create your project, get your API keys to embed the SDK in your Resonance-powered app. Contact us for a trial `here <link to trial page>`_.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -5,25 +5,36 @@ Introduction
 
 This tutorial is intended to get you up and running with the Resonance AI environment. 
 
-**Atooma**'s Resonance AI is a highly integrated and concurrent AI engine to manage interconnected devices and data streams flowing among devices, services and businesses. A **Resonance AI Application** is made up of every interconnected device embedding the Resonance SDK. Once you embed the **Resonance SDK** in one of your app you get all the advantages of a Resonance-powered app.
+**Atooma**'s Resonance AI is a highly integrated and concurrent software engine designed to manage interconnected devices and data streams flowing among apps services and businesses. A **Resonance AI Application** is the realization of a tool that can interconnect all the devices embedding the **Resonance SDK**. Briefly, Resonance AI smooths the great complexity implied in managing a large network of devices, to supply the user with all the possibilities given by the Internet Of Things.
 
 Resonance AI has been designed focusing on:
 
-* `contexts awareness <https://en.wikipedia.org/wiki/Context_awareness>`_ for your devices
-* modularity in building streams of data from different sources 
-* integration of multiple sources for verticals needed by your business
-* live notifications and suggestions to thousands of devices
+* `contexts awareness <https://en.wikipedia.org/wiki/Context_awareness>`_ for your devices: know your peers and gather better intelligence to design better products, 
+* modularity in building streams of data from different sources: simply manage developing activities and usage scenarios for your products,
+* integration of multiple sources for verticals needed by your business: add value to your products by leveraging multiple data sources,
+* live notifications and suggestions to thousands of devices: get feedback from and operate your devices instantly.
+
+These incredible super-powers are made possible by the tools implemented by Resonance. A Resonance AI Application is an instance of the harmonic stacking of:
+
+* the cloud-based Resonance Dashboard,
+* the cloud-based Resonance Rule Engine,
+* the Resonance SDK deployed in the devices running your app.
 
 Basics
 ======================================
 
-Resonance SDK is the core that powers any kind of mobile or embedded app you may want to develop to drive your business. It was defined thank to the experience at Atooma with thousands of users and millions of enabled IF-DO rules.
+Resonance SDK is the core that powers any kind of mobile or embedded app you may want to develop to enhance your business. It has been designed along with the great experience at Atooma, collected by serving thousands of users and enabling millions of IF-DO rules. The Resonance Rule Engine carries on billions of operations by communicating real-time with all the devices running the SDK. You can create your app perfectly fitting your business model and integrate our SDK into it, to get all the advantages of our platform. Once you embed the Resonance SDK in one of your app you get all the advantages of a Resonance-powered app.   
 
-A Resonance AI Application integrates all the devices running your apps; your network of devices can be operated via the **Resonance AI Dashboard**: a Web-based control panel from which applications running on multiple devices can be looked over, and rules and notifications can be triggered and propagated all over your network.
+A Resonance AI Application looks over all the devices embedding the SDK; your network of devices can be operated via the **Resonance Dashboard**: a Web-based control panel from which applications running on multiple devices can be monitored and operated; rules and notifications can be triggered and propagated to devices.
 
-We'll walk through from setup to **running your own Resonance Application**.
+We'll walk through from setup to **running your own Resonance AI Application**.
 
-Resonance-powered apps are Android/iOS/Cloud based applications or devices that allow a user to leverage on the power of connecting multiple devices and apps together, with the final goal to give at final users a contextual experience application: automating recurring tasks and suggesting actions.
+To set up a Resonance AI Application you need to have first access to the Resonance Dashboard: create a Project to obtain an API Key to embed the SDK in your devices. Once you created a Project, you can deploy your API Key within your Resonance-powered apps and start making data useful for your business. Sign-in to https://console.resonance-ai.com
+
+Create a Resonance-powered app for your business
+-----------------------------------------------------------
+
+Resonance-powered apps are Android/iOS/Web based applications or devices that allow a user to leverage on the power of connecting multiple devices and apps together, with the final goal to give at final users a contextual experience application: automating recurring tasks and suggesting actions.
 
 Furthermore sensors, apps and devices are all managed by Resonance as key enabler to new generations of smart devices designed to:
 
@@ -35,8 +46,9 @@ Furthermore sensors, apps and devices are all managed by Resonance as key enable
 
 The power of these apps is deployed by your Resonance AI Application.
 
-To set up a Resonance AI Application you need to have access to the Resonance Dashboard; create a Project to obtain an API Key to embed the SDK in your devices. Once you created a Project, you can deploy your API Key within your Resonance-powered apps and start making data useful for your business. Sign-in to https://console.resonance-ai.com
+You can access documentation about how the SDK works and how it can be embedded into any Android/iOS/Web application `here <add internal link>`_.
 
+Once you have your app running on many devices, you can enjoy the simplicity of managing your network from the `Resonance Dashboard <link to dashboard doc>`_.
 
 What We Believe?
 -----------------------------------------------------
@@ -65,7 +77,7 @@ Building our own App and product has been a perfect strategy to understand what 
 What Is Resonance SDK?
 -----------------------------------------------------
 
-Such enormous validation convinced our team to extend such contextual capabilities not only to the end user’s hands but directly towards device vendors and app developers team.
+Such a great validation convinced our team to extend such contextual capabilities not only to the end user’s hands but directly towards device vendors and app developers team.
 
 Imagine to be able to connect your temperature sensor to our engine and being able to enable contextual experiences on your Smart Home App like: *Every Time the temperature threshold is below a certain level and I'm out of home, activate the air conditioning and store the electrical consumptions info into a Drive Doc*. Well, using the Resonance SDK, you can do it in a matter of seconds!
 
@@ -82,4 +94,4 @@ Having such contextual information then you'll be able to proceed by coding a sp
 What You Need?
 -----------------------------------------------------
 
-Using our Platform is super simple: sign-in to https://console.resonance-ai.com and start to build your contextual application. Create your project, get your API keys to embed in your Resonance-powered app.
+Using our platform is super simple: sign-in to https://console.resonance-ai.com and start to build your contextual application. Create your project, get your API keys to embed the SDK in your Resonance-powered app.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -8,10 +8,10 @@ This tutorial is intended to get you up and running with the Resonance AI enviro
 **Atooma**'s Resonance AI is a highly integrated and concurrent AI engine to manage interconnected devices and data streams flowing among devices, services and businesses. A **Resonance AI Application** is made up of every interconnected device embedding the Resonance SDK. Once you embed the **Resonance SDK** in one of your app you get all the advantages of a Resonance-powered app.
 
 Resonance AI has been designed focusing on:
-- [contexts awareness](https://en.wikipedia.org/wiki/Context_awareness) for your devices
-- modularity in building streams of data from different sources 
-- integration of multiple sources for the needed vertical of your business
-- live notifications and suggestions to thousands of devices
+* [contexts awareness](https://en.wikipedia.org/wiki/Context_awareness) for your devices
+* modularity in building streams of data from different sources 
+* integration of multiple sources for the needed vertical of your business
+* live notifications and suggestions to thousands of devices
 
 Basics
 ======================================

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -9,7 +9,7 @@ This tutorial is intended to get you up and running with the Resonance AI enviro
 
 Resonance AI has been designed focusing on:
 
-* [contexts awareness](https://en.wikipedia.org/wiki/Context_awareness) for your devices
+* `contexts awareness <https://en.wikipedia.org/wiki/Context_awareness>`_ for your devices
 * modularity in building streams of data from different sources 
 * integration of multiple sources for the needed vertical of your business
 * live notifications and suggestions to thousands of devices

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -11,7 +11,7 @@ Resonance AI has been designed focusing on:
 
 * `contexts awareness <https://en.wikipedia.org/wiki/Context_awareness>`_ for your devices
 * modularity in building streams of data from different sources 
-* integration of multiple sources for the needed vertical of your business
+* integration of multiple sources for verticals needed by your business
 * live notifications and suggestions to thousands of devices
 
 Basics

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -3,9 +3,26 @@
 Introduction
 =======================================
 
-This tutorial is intended to get you up and running with the Resonance AI environment. We'll walk through from setup to running your own **Resonance-Powered-App**.
+This tutorial is intended to get you up and running with the Resonance AI environment. 
 
-**Resonance-Powered-Apps** are Android/iOS/Cloud based applications or devices that allow a user to leverage on the power of connecting multiple devices and apps together, with the final goal to give at final users a contextual experience application: automating recurring tasks and suggesting actions.
+**Atooma**'s Resonance AI is a highly integrated and concurrent AI engine to manage interconnected devices and data streams flowing among devices, services and businesses. A **Resonance AI Application** is made up of every interconnected device embedding the Resonance SDK. Once you embed the **Resonance SDK** in one of your app you get all the advantages of a Resonance-powered app.
+
+Resonance AI has been designed focusing on:
+- [contexts awareness](https://en.wikipedia.org/wiki/Context_awareness) for your devices
+- modularity in building streams of data from different sources 
+- integration of multiple sources for the needed vertical of your business
+- live notifications and suggestions to thousands of devices
+
+Basics
+======================================
+
+Resonance SDK is the core that powers any kind of mobile or embedded app you may want to develop to drive your business. It was defined thank to the experience at Atooma with thousands of users and millions of enabled IF-DO rules.
+
+A Resonance AI Application integrates all the devices running your apps; your network of devices can be operated via the **Resonance AI Dashboard**: a Web-based control panel from which applications running on multiple devices can be looked over, and rules and notifications can be triggered and propagated all over your network.
+
+We'll walk through from setup to **running your own Resonance Application**.
+
+Resonance-powered apps are Android/iOS/Cloud based applications or devices that allow a user to leverage on the power of connecting multiple devices and apps together, with the final goal to give at final users a contextual experience application: automating recurring tasks and suggesting actions.
 
 Furthermore sensors, apps and devices are all managed by Resonance as key enabler to new generations of smart devices designed to:
 
@@ -14,6 +31,10 @@ Furthermore sensors, apps and devices are all managed by Resonance as key enable
 * **Analyze** the patterns and get the most out of them.
 
 * **Act** accordingly with the desired action in the right moment for a magic experience.
+
+The power of these apps runs into a Resonance AI Application.
+
+To set up a Resonance AI Application you need to have access to the Resonance Dashboard; create a Project to obtain an API Key to embed the SDK in your devices. Once you created a Project, you can deploy your API Key within your Resonance-powered apps and start making data useful for your business. Sign-in to https://console.resonance-ai.com
 
 
 What We Believe?
@@ -60,4 +81,4 @@ Having such contextual information then you'll be able to proceed by coding a sp
 What You Need?
 -----------------------------------------------------
 
-Using our Platform is super simple: sign-in to https://console.resonance-ai.com and start to build your contextual application.
+Using our Platform is super simple: sign-in to https://console.resonance-ai.com and start to build your contextual application. Create your project, get your API keys to embed in your Resonance-powered app.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -33,7 +33,7 @@ Furthermore sensors, apps and devices are all managed by Resonance as key enable
 
 * **Act** accordingly with the desired action in the right moment for a magic experience.
 
-The power of these apps runs into a Resonance AI Application.
+The power of these apps is deployed by your Resonance AI Application.
 
 To set up a Resonance AI Application you need to have access to the Resonance Dashboard; create a Project to obtain an API Key to embed the SDK in your devices. Once you created a Project, you can deploy your API Key within your Resonance-powered apps and start making data useful for your business. Sign-in to https://console.resonance-ai.com
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -8,6 +8,7 @@ This tutorial is intended to get you up and running with the Resonance AI enviro
 **Atooma**'s Resonance AI is a highly integrated and concurrent AI engine to manage interconnected devices and data streams flowing among devices, services and businesses. A **Resonance AI Application** is made up of every interconnected device embedding the Resonance SDK. Once you embed the **Resonance SDK** in one of your app you get all the advantages of a Resonance-powered app.
 
 Resonance AI has been designed focusing on:
+
 * [contexts awareness](https://en.wikipedia.org/wiki/Context_awareness) for your devices
 * modularity in building streams of data from different sources 
 * integration of multiple sources for the needed vertical of your business

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,97 +1,34 @@
-.. _intro:
+Welcome to Resonance AI SDK documentation!
+======================================================
 
-Introduction
-=======================================
+Welcome to the official reference for developing with Resonance AI Android SDK.
 
-This tutorial is intended to get you up and running with the Resonance AI environment. 
+.. note::
 
-**Atooma**'s Resonance AI is a highly integrated and concurrent software engine designed to manage interconnected devices and data streams flowing among apps services and businesses. A **Resonance AI Application** is the realization of a tool that can interconnect all the devices embedding the **Resonance SDK**. Briefly, Resonance AI smooths the great complexity implied in managing a large network of devices, to supply the user with all the possibilities given by the Internet Of Things.
+	This documentation is a work in progress. We are working hard every day for providing all of you an awesome developer experience, so stay tuned!
 
-Resonance AI has been designed focusing on:
+	Documentation sources are available on `GitHub <https://github.com/atooma/doc-resonance-ai>`_, so if you find typos, errors, or think something can be communicated better, fork repository and make a pull request.
 
-* `contexts awareness <https://en.wikipedia.org/wiki/Context_awareness>`_ for your devices: know your peers and gather better intelligence to design better products, 
-* modularity in building streams of data from different sources: simply manage developing activities and usage scenarios for your products,
-* integration of multiple sources for verticals needed by your business: add value to your products by leveraging multiple data sources,
-* live notifications and suggestions to thousands of devices: get feedback from and operate your devices instantly.
+	We appreciate your understanding and patience!
 
-These incredible super-powers are made possible by the tools implemented by Resonance. A Resonance AI Application is an instance of the harmonic stacking of:
+This documentation is aimed to provide in depth details on how to approach development and it is organized as follows:
 
-* the cloud-based Resonance Dashboard,
-* the cloud-based Resonance Rule Engine,
-* the Resonance SDK deployed in the devices running your app.
+.. toctree::
+	:numbered:
+	:maxdepth: 1
 
-Basics
-======================================
+	intro
+	getstart
+	iosstart
+	android
+	contextapi
+	infoapi
 
-Resonance SDK is the core that powers any kind of mobile or embedded app you may want to develop to enhance your business. It has been designed along with the great experience at Atooma, collected by serving thousands of users and enabling millions of IF-DO rules. The Resonance Rule Engine carries on billions of operations by communicating real-time with all the devices running the SDK. You can create your app perfectly fitting your business model and integrate our SDK into it, to get all the advantages of our platform. Once you embed the Resonance SDK in one of your app you get all the advantages of a Resonance-powered app.   
+..
+	* :ref:`intro` - Here you can find answers to questions like *what is Resonance?* and *what can I do with Resonance SDK?*. Your understanding of Atooma potential starts from here!
+	* :ref:`getstart` - The first step!
+	* :ref:`iosstart` - The iOS first step!
+	* :ref:`android` - The Android first step!
+	* :ref:`contextapi` - Context API section.
+	* :ref:`infoapi` - Info API section.
 
-A Resonance AI Application looks over all the devices embedding the SDK; your network of devices can be operated via the **Resonance Dashboard**: a Web-based control panel from which applications running on multiple devices can be monitored and operated; rules and notifications can be triggered and propagated to devices.
-
-We'll walk through from setup to **running your own Resonance AI Application**.
-
-To set up a Resonance AI Application you need to have first access to the Resonance Dashboard: create a Project to obtain an API Key to embed the SDK in your devices. Once you created a Project, you can deploy your API Key within your Resonance-powered apps and start making data useful for your business. Sign-in to https://console.resonance-ai.com
-
-Create a Resonance-powered app for your business
------------------------------------------------------------
-
-Resonance-powered apps are Android/iOS/Web based applications or devices that allow a user to leverage on the power of connecting multiple devices and apps together, with the final goal to give at final users a contextual experience application: automating recurring tasks and suggesting actions.
-
-Furthermore sensors, apps and devices are all managed by Resonance as key enabler to new generations of smart devices designed to:
-
-* **Listen** to people’s behavior across apps and devices.
-
-* **Analyze** the patterns and get the most out of them.
-
-* **Act** accordingly with the desired action in the right moment for a magic experience.
-
-The power of these apps is deployed by your Resonance AI Application.
-
-You can access documentation about how the SDK works and how it can be embedded into any Android/iOS/Web application `here <add internal link>`_.
-
-Once you have your app running on many devices, you can enjoy the simplicity of managing your network from the `Resonance Dashboard <link to dashboard doc>`_.
-
-What We Believe?
------------------------------------------------------
-
-Within 2020 the number of connected devices will be over than 50 Billion.
-From Connected Cars to Smart Homes, from Wearables to Smartphones all things are getting connected and more intelligent everyday.
-
-Devices are still far from each other - they do not talk - they do not provide cool and useful cross-use-cases to end users. How many of you are using a Smart TV, not only to watch TV programs? How many of you are considering useful a smartwatch device after the first week of adoption?
-
-As result, end users got lost among different OSs and Devices Capabilities turning their connected and smart experience into a nightmare.
-Resonance bring again the user at the centre of the picture, seamlessly connecting devices around him and providing real context aware and predictive aware features.
-
-Developers and Companies focused on building IOT devices and/or Apps can rely on a perfect tool to empower their products capabilities and turning them into a real context aware space.
-
-What Is Resonance - Why There Is An Atooma App On The Market?
----------------------------------------------------------------------
-
-Atooma App was born initially as an Android (also on a light-version for iOS) application aimed to allow end users to create and share automation rules following the *IF and DO* paradigm.
-
-So, using Atooma App users are able to create rules like: *IF I'm running and I plug the headphone DO Launch the music* or *IF I'm driving back to home and my battery level is below 10% DO send an SMS to my wife*.
-
-Today more than 25M of rules have been created and shared among our community and hundreds of apps and devices features are controlled by the Resonance Rule Engine.
-
-Building our own App and product has been a perfect strategy to understand what people love to automate in their life. What they are looking to turn smart into their devices or apps and why they found even hard to use a toolkit like our consumer App.
-
-What Is Resonance SDK?
------------------------------------------------------
-
-Such a great validation convinced our team to extend such contextual capabilities not only to the end user’s hands but directly towards device vendors and app developers team.
-
-Imagine to be able to connect your temperature sensor to our engine and being able to enable contextual experiences on your Smart Home App like: *Every Time the temperature threshold is below a certain level and I'm out of home, activate the air conditioning and store the electrical consumptions info into a Drive Doc*. Well, using the Resonance SDK, you can do it in a matter of seconds!
-
-We estimated every developer can save up to *60%* of coding lines to build context aware use cases by relying on our tools.
-
-We do provide to third party developers a full standalone Platform to collect and to analyze data from a lot of devices and to create intelligence contextual automation with a set of embedded modules to start immediately to build automation use cases just by matching basic lines of LUA scripts using a web console.
-On top of it developers have the opportunity to create their own sensors modules and plug them with our Resonance Cloud platform and leverage on real time prediction based rule suggestions.
-
-We do provide external developers a set of APIs which leverage on the fact that Resonance is able to collect user's behaviors information among hundreds of sensors and apps with the final result to be able to to let your App be aware of what the user is going to do. Imagine to have an API able to let you know if the user is driving back home from work or just simply to understand if the user is in a Bus rather than a Car.
-Having such contextual information then you'll be able to proceed by coding a specific reaction on your own app or eventually leverage on the Resonance Rule Engine to be able to trigger an automation rule based on such context prediction.
-
-.. _intro-needs:
-
-What You Need?
------------------------------------------------------
-
-Using our platform is super simple: sign-in to https://console.resonance-ai.com and start to build your contextual application. Create your project, get your API keys to embed the SDK in your Resonance-powered app.


### PR DESCRIPTION
Ho creato una presentazione iniziale di tutta la piattaforma in `index.rst`. 
Da questa pagina iniziale dovrebbero partire i link alle sezioni della documentazione dedicate a: Dashboard, Rule Engine, SDK Android, SDK iOS. Nonché i link alla pagina di "Request Trial".
